### PR TITLE
Support HA's new native values, which handles unit conversions

### DIFF
--- a/custom_components/sensorpush/const.py
+++ b/custom_components/sensorpush/const.py
@@ -1,5 +1,3 @@
-from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
-
 SENSORPUSH_DOMAIN = 'sensorpush'
 
 ATTRIBUTION="Data by SensorPush"
@@ -13,7 +11,6 @@ ATTR_ALERT_MIN       = 'alert_min'
 ATTR_ALERT_MAX       = 'alert_max'
 ATTR_ALERT_ENABLED   = 'alert_enabled'
 
-CONF_UNIT_SYSTEM = 'unit_system'
 CONF_MAXIMUM_AGE = 'maximum_age' # maximum age (in minutes) of observations before they expire
 
 MEASURE_TEMP = "temperature"
@@ -49,25 +46,11 @@ MEASURES = {
     }
 }
 
-UNIT_SYSTEM_IMPERIAL = 'imperial'
-UNIT_SYSTEM_METRIC = 'metric'
-
 UNIT_SYSTEMS = {
-    UNIT_SYSTEM_IMPERIAL: { 
-        'system': 'imperial',
-        MEASURE_BAROMETRIC_PRESSURE: 'inHg',
-        MEASURE_DEWPOINT: TEMP_FAHRENHEIT,
-        MEASURE_HUMIDITY: '%', # 'Rh'
-        MEASURE_TEMP: TEMP_FAHRENHEIT,
-        MEASURE_VPD: 'kPa'
-    },
-
-    UNIT_SYSTEM_METRIC: { 
-        'system': 'metric',
-        MEASURE_BAROMETRIC_PRESSURE: 'mbar',
-        MEASURE_DEWPOINT: TEMP_CELSIUS, # FIXME: icon mdi:temperature-celsius
-        MEASURE_HUMIDITY: '%', # 'Rh'
-        MEASURE_TEMP: TEMP_CELSIUS,
-        MEASURE_VPD: 'kPa'
-    }
+    'system': 'imperial',
+    MEASURE_BAROMETRIC_PRESSURE: 'inHg',
+    MEASURE_DEWPOINT: '°F',
+    MEASURE_HUMIDITY: '%', # 'Rh'
+    MEASURE_TEMP: '°F',
+    MEASURE_VPD: 'kPa'
 }

--- a/custom_components/sensorpush/sensor.py
+++ b/custom_components/sensorpush/sensor.py
@@ -13,8 +13,7 @@ from homeassistant.components.sensor import SensorEntity
 
 from . import ( SensorPushEntity, SENSORPUSH_SERVICE, SENSORPUSH_SAMPLES)
 
-from .const import (SENSORPUSH_DOMAIN, CONF_UNIT_SYSTEM, MEASURES,
-                    UNIT_SYSTEM_IMPERIAL, UNIT_SYSTEM_METRIC, UNIT_SYSTEMS)
+from .const import (SENSORPUSH_DOMAIN, MEASURES, UNIT_SYSTEMS)
 
 LOG = logging.getLogger(__name__)
 
@@ -29,8 +28,6 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
         LOG.error("NOT setting up SensorPush -- SENSORPUSH_SERVICE has not been initialized")
         return
 
-    unit_system = hass.data[SENSORPUSH_DOMAIN][CONF_UNIT_SYSTEM]
-
     hass_sensors = []
     for sensor_info in sensorpush_service.sensors.values():
         LOG.info(f"SensorInfo: {sensor_info} -- {type(sensor_info)}")
@@ -44,7 +41,7 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
         for measure in MEASURES:
             # only include measurements supported by this sensor
             if measure in supported_measurements:
-                sensor = SensorPushMeasurement(hass, config, sensor_info, unit_system, measure)
+                sensor = SensorPushMeasurement(hass, config, sensor_info, measure)
                 hass_sensors.append(sensor)
 
     # execute callback to add new entities
@@ -53,14 +50,10 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
 # pylint: disable=too-many-instance-attributes
 class SensorPushMeasurement(SensorPushEntity, SensorEntity):
     """Measurement sensor for a SensorPush device"""
-    def __init__(self, hass, config, sensor_info, unit_system, measure):
+    def __init__(self, hass, config, sensor_info, measure):
         self._name = MEASURES[measure]['name']
         self._state = None
-        super().__init__(hass, config, self._name, sensor_info, unit_system, measure)
-
-    @property
-    def unit_of_measurement(self):
-        return UNIT_SYSTEMS[self._unit_system][self._field_name]
+        super().__init__(hass, config, self._name, sensor_info, measure)
 
     @property
     def unique_id(self):


### PR DESCRIPTION
HA 2022.7 [supports native temperature conversions](https://www.home-assistant.io/blog/2022/07/06/release-20227/#change-any-weather-unit-to-your-preference) with per-entity preferences for units of measurement. However, this change had the side effect of causing all temperatures emitted by the SensorPush integration to be in fahrehnheit.

This PR updates the integration to use the new "native"  temperature values, and refactors it a bit to remove the old internal metric/imperial logic. It now always uses imperial measurements (though no longer relies on the old unit of measurement config setting), and lets HA do any conversions with the new mechanism.

⚠️ Note: One unfortunate side effect is that this will pollute history somewhat, as it will not retroactively convert data. This means that your sensor history may show the old fahrenheit values in the same celsius graph.

ℹ️ This will also cause _all_ entities to default to their imperial units. I don't have a sensor that emits barometric pressure, so I cannot test whether HA will convert this or not.

## Testing done
- I deployed this branch to a local instance

#### ✅ SensorPush temperature entity now has select for Unit of Measurement

![sensor_push_sensor_units](https://user-images.githubusercontent.com/37455/178238411-f459fa1e-7529-4579-b48f-4f756d9a8438.png)

#### ✅ HA properly converts/displays value based on selected unit of measurement
![sensorpush_sensor_history](https://user-images.githubusercontent.com/37455/178238432-7cdd1f20-b240-4edc-ad2e-a0872cb49bd5.png)

