### PR TITLE
The latest HA requires this config_flow option to be set.

### DIFF
--- a/custom_components/sensorpush/manifest.json
+++ b/custom_components/sensorpush/manifest.json
@@ -7,5 +7,6 @@
     "version": "0.1.4",
     "dependencies": [],
     "codeowners": ["@rsnodgrass"],
-    "iot_class": "cloud_polling"
+    "iot_class": "cloud_polling",
+    "config_flow": false
 }


### PR DESCRIPTION
I tried using this component today in my new Home Assistant setup and I couldn't get it to load initially.  After a bit of research, it appears that HA now requires the config_flow value to be set to true or false.  I've chosen false since I don't think there's any UI-based configuration to this component.  Once added, I was able to start reading values from my sensors!